### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ serde = { version = "1.0", features = ["derive"] }
 
 base64 = "0.22"
 
-rand_core = { version = "0.6", default-features = false }
 rand = { version = "0.8", default-features = false, features = [
   "std_rng",
   "std",
@@ -32,14 +31,12 @@ rsa = "0.9"
 sha2 = { version = "0.10", features = ["oid"] }
 
 hmac = "0.12"
-subtle = "2.6"
 serde_plain = "1.0"
 
 [dev-dependencies]
 # For the custom chrono example
 chrono = "0.4.38"
 criterion = "0.5.1"
-reqwest = { version = "0.12.7", features = ["blocking", "json"] }
 
 # Test interop with the original.
 jsonwebtoken = "9.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,27 +20,29 @@ edition = "2021"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
-base64 = "0.21.0"
+base64 = "0.22"
 
 rand_core = { version = "0.6", default-features = false }
-rand = { version = "0.8", default-features = false, features = ["std_rng", "std"] }
+rand = { version = "0.8", default-features = false, features = [
+  "std_rng",
+  "std",
+] }
 
-rsa = "0.8"
-sha2 = { version = "0.10.6", features = ["oid"] }
+rsa = "0.9"
+sha2 = { version = "0.10", features = ["oid"] }
 
-hmac = "0.12.1"
-subtle = "2.4.1"
-crypto-mac = "0.11.1"
-serde_plain = "1.0.1"
+hmac = "0.12"
+subtle = "2.6"
+serde_plain = "1.0"
 
 [dev-dependencies]
 # For the custom chrono example
-chrono = "0.4.19"
-criterion = "0.3.5"
-reqwest = { version = "0.11.9", features = ["blocking", "json"] }
+chrono = "0.4.38"
+criterion = "0.5.1"
+reqwest = { version = "0.12.7", features = ["blocking", "json"] }
 
 # Test interop with the original.
-jsonwebtoken = "8.3.0"
+jsonwebtoken = "9.3.0"
 
 [[bench]]
 name = "jwt"

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -2,7 +2,7 @@
 use crate::errors::{ErrorKind, Result};
 use crate::serialization::{b64_decode, b64_encode};
 use crate::{errors, Algorithm};
-use rsa::SignatureScheme;
+use rsa::traits::SignatureScheme;
 use rsa::{pss::Pss, Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey};
 use sha2::{Digest, Sha256, Sha384, Sha512};
 

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -172,7 +172,7 @@ impl JwkDecodingKeySet {
                 alg == header_alg
             } else {
                 // If alg is not set, pass, otherwise fail.
-                !matches!(key.alg, Some(_))
+                key.alg.is_none()
             }
         })
         .find_map(|key| decode(token, &key.key, validation).ok())


### PR DESCRIPTION
Update cargo dependencies and fix clippy error.

I've decided to lock only the minor version of all the dependencies, to give more flexibility to the client importing this library.

Here's the list of unused dependencies that I've removed:
- `crypto-mac`, removed also because it's unmaintained (see https://github.com/RustCrypto/traits/issues/1609#issuecomment-2220151731).
- `rand_core`
- `subtle`
- `reqwest` (it was just a dev dependency)

